### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "redact-composer"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "rand",
  "redact-composer-core",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "redact-composer-musical"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "rand",
  "redact-composer-core",

--- a/redact-composer-musical/CHANGELOG.md
+++ b/redact-composer-musical/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/dousto/redact-composer/compare/redact-composer-musical-v0.1.3...redact-composer-musical-v0.1.4) - 2024-01-19
+
+### Other
+- Update Element link to point to trait instead of macro
+
 ## [0.1.3](https://github.com/dousto/redact-composer/compare/redact-composer-musical-v0.1.2...redact-composer-musical-v0.1.3) - 2024-01-18
 
 ### Other

--- a/redact-composer-musical/Cargo.toml
+++ b/redact-composer-musical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redact-composer-musical"
 description = "Music theory domain models and utilities packaged with redact-composer"
-version = "0.1.3"
+version = "0.1.4"
 repository = "https://github.com/dousto/redact-composer"
 authors = ["Doug Stoeckmann <dousto@gmail.com>"]
 keywords = ["music", "theory"]

--- a/redact-composer/CHANGELOG.md
+++ b/redact-composer/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/dousto/redact-composer/compare/redact-composer-v0.1.3...redact-composer-v0.1.4) - 2024-01-19
+
+### Other
+- updated the following local packages: redact-composer-musical
+
 ## [0.1.3](https://github.com/dousto/redact-composer/compare/redact-composer-v0.1.2...redact-composer-v0.1.3) - 2024-01-18
 
 ### Other

--- a/redact-composer/Cargo.toml
+++ b/redact-composer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redact-composer"
 description = "A library for building modular musical composers."
-version = "0.1.3"
+version = "0.1.4"
 repository = "https://github.com/dousto/redact-composer"
 authors = ["Doug Stoeckmann <dousto@gmail.com>"]
 keywords = ["compose", "music"]
@@ -14,7 +14,7 @@ edition = "2021"
 redact-composer-core = { path = "../redact-composer-core", version = "0.1.2" }
 
 redact-composer-derive = { optional = true, path = "../redact-composer-derive", version = "0.1.0" }
-redact-composer-musical = { optional = true, path = "../redact-composer-musical", version = "0.1.3" }
+redact-composer-musical = { optional = true, path = "../redact-composer-musical", version = "0.1.4" }
 redact-composer-midi = { optional = true, path = "../redact-composer-midi", version = "0.1.3" }
 
 [features]


### PR DESCRIPTION
## 🤖 New release
* `redact-composer-musical`: 0.1.3 -> 0.1.4
* `redact-composer`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `redact-composer-musical`
<blockquote>

## [0.1.4](https://github.com/dousto/redact-composer/compare/redact-composer-musical-v0.1.3...redact-composer-musical-v0.1.4) - 2024-01-19

### Other
- Update Element link to point to trait instead of macro
</blockquote>

## `redact-composer`
<blockquote>

## [0.1.4](https://github.com/dousto/redact-composer/compare/redact-composer-v0.1.3...redact-composer-v0.1.4) - 2024-01-19

### Other
- updated the following local packages: redact-composer-musical
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).